### PR TITLE
fix(nit): Use reduce instead of map in mapScoresToUsers function

### DIFF
--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -15,18 +15,18 @@ export const mapScoresToUsers = (
   scores: Score[],
   users: User[]
 ): UserScore[] => {
-  const idsToUserNameMap: { [key: number]: string } = {}
+  const idsToUserNameMap = users.reduce(
+    (acc: { [key: number]: string }, user) => {
+      acc[user._id] = user.name
+      return acc
+    },
+    {}
+  )
 
-  users.map((user) => {
-    idsToUserNameMap[user._id] = user.name
-  })
-
-  const scoresWithUsers = scores.map((score) => {
-    return {
-      name: idsToUserNameMap[score.userId],
-      score: score.score,
-    }
-  })
+  const scoresWithUsers = scores.map((score) => ({
+    name: idsToUserNameMap[score.userId],
+    score: score.score,
+  }))
   // NOTE: if we assume that we might get incorrectly formated data, the following iteration will make sure that the resulting array has no mismatches
   // .filter((obj) => obj.name !== undefined)
 


### PR DESCRIPTION
This is simply a matter of taste to either use `reduce` or `map` in `mapScoresToUsers`.

Arguably, this also makes `idsToUserNameMap` immutable, but since it is only used once in this helper function, I don't think that is ever a concern.